### PR TITLE
Do letter colouring logic with context of full word

### DIFF
--- a/script.js
+++ b/script.js
@@ -266,22 +266,41 @@ class GameState {
 		}
 
 		if (e.animationName === "down") {
-			const character = elem.textContent;
-			const position  = Array.prototype.indexOf.call(elem.parentElement.children, elem);
+			const row = elem.parentElement;
+			const position  = Array.prototype.indexOf.call(row.children, elem);
 
-			if (this.targetWord[position] === character) {
-				elem.classList.add("correct");
-				document.getElementById(character).classList.add("correct");
-			} else if (this.targetWord.includes(character)) {
-				elem.classList.add("partial");
-				document.getElementById(character).classList.add("partial");
-			} else {
-				elem.classList.add("absent");
-				document.getElementById(character).classList.add("absent");
-			}
-
+			elem.classList.add(this.getGuessState(row.textContent)[position]);
 			elem.classList.add("animation-up");
 		}
+	}
+
+	getGuessState(line) {
+		const currentAnswer = line.split("");
+		const target = this.targetWord.split("");
+
+		let state = array(this.wordLength, () => "absent");
+
+		for (let i = 0; i < this.wordLength; ++i) {
+			if (currentAnswer[i] != target[i]) {
+				continue;
+			}
+			state[i] = "correct";
+			target[i] = "";
+		}
+
+		for (let i = 0; i < this.wordLength; ++i) {
+			if (state[i] == "correct") {
+				continue;
+			}
+			if (target.indexOf(currentAnswer[i]) === -1) {
+				continue;
+			}
+
+			state[i] = "partial";
+			target[target.indexOf(currentAnswer[i])] = "";
+		}
+
+		return state;
 	}
 
 	showVictory() {


### PR DESCRIPTION
Previously the logic for showing the state of letter looked only at the letter and the whole target word, ignoring the other letters that had been guessed.

The fix now works by looking at both words in full, meaning that putting a second copy of a letter that only appears once in the target word will be be marked as incorrect/absent.

Fixes #3 